### PR TITLE
Update Apple-clang-format.podspec

### DIFF
--- a/Apple-clang-format.podspec
+++ b/Apple-clang-format.podspec
@@ -1,12 +1,11 @@
 Pod::Spec.new do |s|
-  s.name         = "Apple-clang-format"
-  s.version      = "0.0.1"
-  s.summary      = "A .clang-format file as similar as you can get to Apples code style."
-  s.homepage     = "https://github.com/haaakon/Apple-clang-format"
-  s.license      = { :type => 'MIT' }
-  s.author       = { "Haaakon Bogen" => "hakon.bogen@gmail.com" }
-  s.source       = { :git => "https://github.com/haaakon/Apple-clang-format.git", :tag => "0.0.1" }
-  s.platform     = :ios, '5.0'
-  s.source_files = ".*"
+  s.name           = "Apple-clang-format"
+  s.version        = "0.0.1"
+  s.summary        = "A .clang-format file as similar as you can get to Apples code style."
+  s.homepage       = "https://github.com/haaakon/Apple-clang-format"
+  s.license        = { :type => 'MIT' }
+  s.author         = { "Haaakon Bogen" => "hakon.bogen@gmail.com" }
+  s.source         = { :git => "https://github.com/haaakon/Apple-clang-format.git", :tag => "0.0.1" }
+  s.platform       = :ios, '5.0'
+  s.preserve_paths = ".clang-format"
 end
-


### PR DESCRIPTION
Here is a Xcode warning.
`warning: no rule to process file '/.../Pods/Apple-clang-format/.clang-format' of type text for architecture i386`
Because `.clang-format` is NOT a source file.
