### PR TITLE
Set BreakBeforeBraces to Attach

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -37,7 +37,7 @@ Cpp11BracedListStyle: true
 Standard: Cpp11
 TabWidth: 8
 UseTab: Never
-BreakBeforeBraces: Linux
+BreakBeforeBraces: Attach
 IndentFunctionDeclarationAfterType: true
 SpacesInParentheses: false
 SpacesInAngles:  false

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Cpp11BracedListStyle: true
 Standard: Cpp11
 TabWidth: 8
 UseTab: Never
-BreakBeforeBraces: Stroustrup
+BreakBeforeBraces: Attach
 IndentFunctionDeclarationAfterType: true
 SpacesInParentheses: false
 SpacesInAngles:  false


### PR DESCRIPTION
Even though I've seen code from Apple breaking a line before opening braces after a method declaration (just like in `BreakBeforeBraces: Linux`) I'd say that setting it to `Attach` is a better option considering that all the code templates on Xcode 6 and the [WatchKit Lister App](https://developer.apple.com/library/prerelease/ios/samplecode/Lister/Introduction/Intro.html) do not break a line before braces.
