### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Apple .clang-format
 
 A .clang-format file as similar as you can get to Apple's code style.
 
-##Installation
+## Installation
 1. Download the [ClangFormat-Xcode plugin](https://github.com/travisjeffery/ClangFormat-Xcode)
 2. Download this .clang-format file and put it in the root folder of your project.
 3. Go to **Edit** > **Clang Format**, choose **File**. It will choose the .clang-format file if it's in the root folder of the project.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
